### PR TITLE
Import mysql dump into sqlite to be easy consumable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,8 @@
   "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "script"
+  },
+  "rules": {
+    "no-underscore-dangle": 0
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+We would be super happy if you want to help with bringing this
+tool live.
+
+## Setup project
+
+Get the sourcecode and install its dependencies
+
+```
+git clone git@github.com:babel/phabricator-to-github.git .
+npm i
+```
+
+The next step is to obtain an mysql dump from phabricator. You can
+download one [here](https://drive.google.com/open?id=0B9zghAL0eXPVV2d4ZVAteU8xZUk).
+
+Once you have a dump you need to convert and import it
+
+```
+./bin/phaway.js import-mysql-dump path/to/dump.sql
+```
+
+At this point your a completely set and can start working on writing the migration flows.

--- a/bin/mysql2sqlite
+++ b/bin/mysql2sqlite
@@ -1,0 +1,184 @@
+#!/usr/bin/awk -f
+
+# Authors: @esperlu, @artemyk, @gkuenning, @dumblob
+
+BEGIN {
+  if (ARGC != 2) {
+      printf "%s\n%s\n",
+          "USAGE: mysql2sqlite.sh dump_mysql.sql > dump_sqlite3.sql",
+    "       file name - (dash) is not supported, because - means stdin" > "/dev/stderr"
+      err=1  # do not execute the END rule
+      exit 1
+  }
+  FS=",$"
+  print "PRAGMA synchronous = OFF;"
+  print "PRAGMA journal_mode = MEMORY;"
+  print "BEGIN TRANSACTION;"
+}
+
+# CREATE TRIGGER statements have funny commenting. Remember we are in trigger.
+/^\/\*.*(CREATE.*TRIGGER|create.*trigger)/ {
+  gsub( /^.*(TRIGGER|trigger)/, "CREATE TRIGGER" )
+  print
+  inTrigger = 1
+  next
+}
+# The end of CREATE TRIGGER has a stray comment terminator
+/(END|end) \*\/;;/ { gsub( /\*\//, "" ); print; inTrigger = 0; next }
+# The rest of triggers just get passed through
+inTrigger != 0 { print; next }
+
+# CREATE VIEW looks like a TABLE in comments
+/^\/\*.*(CREATE.*TABLE|create.*table)/ {
+  inView = 1
+  next
+}
+# The end of CREATE VIEW
+/^(\).*(ENGINE|engine).*\*\/;)/ {
+  inView = 0;
+  next
+}
+# The rest of view just get passed through
+inView != 0 { next }
+
+# Skip other comments
+/^\/\*/ { next }
+
+# Print all `INSERT` lines. The single quotes are protected by another single quote.
+( /^ *\(/ && /\) *[,;] *$/ ) || /^(INSERT|insert)/ {
+  prev = "";
+  gsub( /\\\047/, "\047\047" )  # single quote
+  gsub( /\\\047\047,/, "\\\047," )
+  gsub( /\\n/, "\n" )
+  gsub( /\\r/, "\r" )
+  gsub( /\\"/, "\"" )
+  gsub( /\\\\/, "\\" )
+  gsub( /\\\032/, "\032" )  # substitute
+  # sqlite3 is limited to 16 significant digits of precision
+  while ( match( $0, /0x[0-9a-fA-F]{17}/ ) ) {
+    hexIssue = 1
+    sub( /0x[0-9a-fA-F]+/, substr( $0, RSTART, RLENGTH-1 ), $0 )
+  }
+  print
+  next
+}
+
+# CREATE DATABASE is not supported
+/^(CREATE.*DATABASE|create.*database)/ { next }
+
+# Print the `CREATE` line as is and capture the table name.
+/^(CREATE|create)/ {
+  if ( $0 ~ /IF NOT EXISTS|if not exists/ || $0 ~ /TEMPORARY|temporary/ ){
+    caseIssue = 1
+  }
+  if ( match( $0, /`[^`]+/ ) ) {
+    tableName = substr( $0, RSTART+1, RLENGTH-1 )
+  }
+  aInc = 0
+  prev = ""
+  firstInTable = 1
+  print
+  next
+}
+
+# Replace `FULLTEXT KEY` (probably other `XXXXX KEY`)
+/^  (FULLTEXT KEY|fulltext key)/ { gsub( /.+(KEY|key)/, "  KEY" ) }
+
+# Get rid of field lengths in KEY lines
+/ (PRIMARY |primary )?(KEY|key)/ { gsub( /\([0-9]+\)/, "" ) }
+
+aInc == 1 && /PRIMARY KEY|primary key/ { next }
+
+# Replace COLLATE xxx_xxxx_xx statements with COLLATE BINARY
+/ (COLLATE|collate) [a-z0-9_]*/ { gsub( /(COLLATE|collate) [a-z0-9_]*/, "COLLATE BINARY" ) }
+
+# Print all fields definition lines except the `KEY` lines.
+/^  / && !/^(  (KEY|key)|\);)/ {
+  if ( match( $0, /[^"`]AUTO_INCREMENT|auto_increment[^"`]/)) {
+    aInc = 1;
+    gsub( /AUTO_INCREMENT|auto_increment/, "PRIMARY KEY AUTOINCREMENT" )
+  }
+  gsub( /(UNIQUE KEY|unique key) `.*` /, "UNIQUE " )
+  gsub( /(CHARACTER SET|character set) [^ ]+[ ,]/, "" )
+  gsub( /DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP|default current_timestamp on update current_timestamp/, "" )
+  gsub( /(COLLATE|collate) [^ ]+ /, "" )
+  gsub( /(ENUM|enum)[^)]+\)/, "text " )
+  gsub( /(SET|set)\([^)]+\)/, "text " )
+  gsub( /UNSIGNED|unsigned/, "" )
+  gsub( /` [^ ]*(INT|int)[^ ]*/, "` integer" )
+  # field comments are not supported
+  gsub( / (COMMENT|comment).+$/, "" )
+  # Get commas off end of line
+  gsub( /,.?$/, "")
+  if ( prev ){
+    if ( firstInTable ){
+      print prev
+      firstInTable = 0
+    }
+    else print "," prev
+  }
+  else {
+    # FIXME check if this is correct in all cases
+    if ( match( $1,
+        /(CONSTRAINT|constraint) \".*\" (FOREIGN KEY|foreign key)/ ) )
+      print ","
+  }
+  prev = $1
+}
+
+/ ENGINE| engine/ {
+  if (prev) {
+    if (firstInTable) {
+      print prev
+      firstInTable = 0
+    }
+    else print "," prev
+    # else print prev
+  }
+  prev=""
+  print ");"
+  next
+}
+# `KEY` lines are extracted from the `CREATE` block and stored in array for later print 
+# in a separate `CREATE KEY` command. The index name is prefixed by the table name to 
+# avoid a sqlite error for duplicate index name.
+/^(  (KEY|key)|\);)/ {
+  if (prev) {
+    if (firstInTable) {
+      print prev
+      firstInTable = 0
+    }
+    else print "," prev
+    # else print prev
+  }
+  prev = ""
+  if ($0 == ");"){
+    print
+  } else {
+    if (  match( $0, /`[^`]+/ ) ) {
+      indexName = substr( $0, RSTART+1, RLENGTH-1 )
+    }
+    if ( match( $0, /\([^()]+/ ) ) {
+      indexKey = substr( $0, RSTART+1, RLENGTH-1 )
+    }
+    # idx_ prefix to avoid name clashes (they really happen!)
+    key[tableName]=key[tableName] "CREATE INDEX \"idx_" tableName "_" indexName "\" ON \"" tableName "\" (" indexKey ");\n"
+  }
+}
+
+END {
+  if (err) { exit 1};
+  # print all `KEY` creation lines.
+  for (table in key) printf key[table]
+
+  print "END TRANSACTION;"
+
+  if ( hexIssue ){
+    print "WARN Hexadecimal numbers longer than 16 characters has been trimmed." | "cat >&2"
+  }
+  if ( caseIssue ){
+    print "WARN Pure sqlite identifiers are case insensitive (even if quoted\n" \
+          "     or if ASCII) and doesnt cross-check TABLE and TEMPORARY TABLE\n" \
+          "     identifiers. Thus expect errors like \"table T has no column named F\"." | "cat >&2"
+  }
+}

--- a/bin/mysql2sqlite
+++ b/bin/mysql2sqlite
@@ -48,7 +48,6 @@ inView != 0 { next }
 ( /^ *\(/ && /\) *[,;] *$/ ) || /^(INSERT|insert)/ {
   prev = "";
   gsub( /\\\047/, "\047\047" )  # single quote
-  gsub( /\\\047\047,/, "\\\047," )
   gsub( /\\n/, "\n" )
   gsub( /\\r/, "\r" )
   gsub( /\\"/, "\"" )

--- a/bin/mysql2sqlite
+++ b/bin/mysql2sqlite
@@ -47,7 +47,11 @@ inView != 0 { next }
 # Print all `INSERT` lines. The single quotes are protected by another single quote.
 ( /^ *\(/ && /\) *[,;] *$/ ) || /^(INSERT|insert)/ {
   prev = "";
+  gsub( /\\\\\\\047/, "\\\\\\@@escapedquote@@" )  # single quote
+  gsub( /\\\\\047/, "\\\\@@realquote@@" )  # single quote
   gsub( /\\\047/, "\047\047" )  # single quote
+  gsub( /@@realquote@@/, "\047" )  # single quote
+  gsub( /@@escapedquote@@/, "\047\047" )  # single quote
   gsub( /\\n/, "\n" )
   gsub( /\\r/, "\r" )
   gsub( /\\"/, "\"" )
@@ -138,8 +142,8 @@ aInc == 1 && /PRIMARY KEY|primary key/ { next }
   print ");"
   next
 }
-# `KEY` lines are extracted from the `CREATE` block and stored in array for later print 
-# in a separate `CREATE KEY` command. The index name is prefixed by the table name to 
+# `KEY` lines are extracted from the `CREATE` block and stored in array for later print
+# in a separate `CREATE KEY` command. The index name is prefixed by the table name to
 # avoid a sqlite error for duplicate index name.
 /^(  (KEY|key)|\);)/ {
   if (prev) {

--- a/bin/phaway-import-mysql-dump.js
+++ b/bin/phaway-import-mysql-dump.js
@@ -30,4 +30,4 @@ if (!file) showErrorAndExit('no file given');
 // eslint-disable-next-line no-nested-ternary
 const logLevel = program.debug ? 'debug' : (program.verbose ? 'verbose' : 'info');
 
-importMysqlDump(file, createLoggerFactory(logLevel)('import-mysql-dump'));
+importMysqlDump(file, createLoggerFactory(logLevel));

--- a/bin/phaway-import-mysql-dump.js
+++ b/bin/phaway-import-mysql-dump.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+const program = require('commander');
+const pjson = require('../package.json');
+const path = require('path');
+const importMysqlDump = require('../src/importMysqlDump');
+const createLoggerFactory = require('../src/utils/createLoggerFactory');
+
+function showErrorAndExit(error) {
+  console.error(`  error: ${error}`); // eslint-disable-line no-console
+  program.outputHelp();
+  process.exit(1);
+}
+
+let file;
+
+program
+  .version(pjson.version)
+  .description('Import phabricator mysql dump into sqlite')
+  .arguments('<file>')
+  .option('-v, --verbose', 'Change log level to verbose')
+  .option('-d, --debug', 'Change log level to debug')
+  .action(argFile => {
+    file = path.resolve(process.cwd(), argFile);
+  })
+  .parse(process.argv);
+
+if (!file) showErrorAndExit('no file given');
+
+// eslint-disable-next-line no-nested-ternary
+const logLevel = program.debug ? 'debug' : (program.verbose ? 'verbose' : 'info');
+
+importMysqlDump(file, createLoggerFactory(logLevel)('import-mysql-dump'));

--- a/bin/phaway-migrate.js
+++ b/bin/phaway-migrate.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+const program = require('commander');
+const pjson = require('../package.json');
+const migrate = require('../src/migrate');
+const createLoggerFactory = require('../src/utils/createLoggerFactory');
+
+program
+  .description('Migrate Phabricator issues to Github')
+  .version(pjson.version)
+  .option('-v, --verbose', 'Change log level to verbose')
+  .option('-d, --debug', 'Change log level to debug')
+  .parse(process.argv);
+
+// eslint-disable-next-line no-nested-ternary
+const logLevel = program.debug ? 'debug' : (program.verbose ? 'verbose' : 'info');
+
+migrate(createLoggerFactory(logLevel));

--- a/bin/phaway.js
+++ b/bin/phaway.js
@@ -7,6 +7,5 @@ program
   .version(pjson.version)
   .command('import-mysql-dump <file>', 'Import phabricator mysql dump into sqlite')
   .command('migrate', 'Migrate Phabricator issues to Github')
-  .command('prune-db', 'Prune sqlite')
   .parse(process.argv);
 

--- a/bin/phaway.js
+++ b/bin/phaway.js
@@ -2,17 +2,11 @@
 'use strict';
 const program = require('commander');
 const pjson = require('../package.json');
-const migrate = require('../src/migrate').migrate;
-const createLoggerFactory = require('../src/utils/createLoggerFactory');
 
 program
-  .description('Migrate Phabricator issues to Github')
   .version(pjson.version)
-  .option('-v, --verbose', 'Change log level to verbose')
-  .option('-d, --debug', 'Change log level to debug')
+  .command('import-mysql-dump <file>', 'Import phabricator mysql dump into sqlite')
+  .command('migrate', 'Migrate Phabricator issues to Github')
+  .command('prune-db', 'Prune sqlite')
   .parse(process.argv);
 
-// eslint-disable-next-line no-nested-ternary
-const logLevel = program.debug ? 'debug' : (program.verbose ? 'verbose' : 'info');
-
-migrate(createLoggerFactory(logLevel));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "A tool to migrate phabricator issues to github",
-  "main": "src/migrate.js",
   "bin": {
     "phaway": "./bin/phaway.js"
   },
@@ -12,7 +11,8 @@
     "lint": "eslint src/ bin/",
     "precommit": "npm run check",
     "preversion": "npm run check",
-    "test": "ava tests/"
+    "test": "ava tests/",
+    "update-mysql2sqlite": "curl -o bin/mysql2sqlite https://raw.githubusercontent.com/dumblob/mysql2sqlite/master/mysql2sqlite && chmod +x bin/mysql2sqlite"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "github-api": "^2.3.0",
+    "sqlite3": "^3.1.4",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/src/import/convertToSqlite.js
+++ b/src/import/convertToSqlite.js
@@ -1,7 +1,6 @@
 'use strict';
 const path = require('path');
 const exec = require('child_process').exec;
-const formatCliMessages = require('../utils/formatCliMessages');
 const prepareBuildDirectory = require('./prepareBuildDirectory');
 
 module.exports = function convertToSqlite(file, targetFile, log, callback) {
@@ -17,8 +16,8 @@ module.exports = function convertToSqlite(file, targetFile, log, callback) {
       `${path.join(__dirname, '../../bin/mysql2sqlite')} ${file} > ${targetFile}`
     );
 
-    convert.stdout.on('data', formatCliMessages(log.verbose));
-    convert.stderr.on('data', formatCliMessages(log.error));
+    convert.stdout.on('data', log.verbose);
+    convert.stderr.on('data', log.error);
 
     convert.on('close', () => {
       log.info('Finished converting');

--- a/src/import/convertToSqlite.js
+++ b/src/import/convertToSqlite.js
@@ -1,0 +1,29 @@
+'use strict';
+const path = require('path');
+const exec = require('child_process').exec;
+const formatCliMessages = require('../utils/formatCliMessages');
+const prepareBuildDirectory = require('./prepareBuildDirectory');
+
+module.exports = function convertToSqlite(file, targetFile, log, callback) {
+  prepareBuildDirectory(targetFile, log, err => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    log.info('Start converting mysql dump to sqlite');
+
+    const convert = exec(
+      `${path.join(__dirname, '../../bin/mysql2sqlite')} ${file} > ${targetFile}`
+    );
+
+    convert.stdout.on('data', formatCliMessages(log.verbose));
+    convert.stderr.on('data', formatCliMessages(log.error));
+
+    convert.on('close', () => {
+      log.info('Finished converting');
+
+      if (callback) callback();
+    });
+  });
+};

--- a/src/import/prepareBuildDirectory.js
+++ b/src/import/prepareBuildDirectory.js
@@ -1,0 +1,19 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function importDump(targetFile, log, callback) {
+  log.info(`Deleting old ${targetFile}`);
+  fs.unlink(targetFile, err => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    log.info('Create directory /build');
+    fs.mkdir(path.dirname(targetFile), () => {
+      if (err) callback(err);
+      else callback();
+    });
+  });
+};

--- a/src/importMysqlDump.js
+++ b/src/importMysqlDump.js
@@ -1,0 +1,28 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const exec = require('child_process').exec;
+const formatCliMessages = require('./utils/formatCliMessages');
+
+const targetFile = 'build/sqlitedump.sql';
+
+module.exports = function importDump(file, log) {
+  log.info(`Deleting old ${targetFile}`);
+  fs.unlinkSync(targetFile);
+
+  log.info('Create directory /build');
+  fs.mkdir(path.join(__dirname, '../build'), () => {
+    log.info('Start converting mysql dump to sqlite');
+
+    const convert = exec(
+      `${path.join(__dirname, '../bin/mysql2sqlite')} ${file} > ${targetFile}`
+    );
+
+    convert.stdout.on('data', formatCliMessages(log.verbose));
+    convert.stderr.on('data', formatCliMessages(log.error));
+
+    convert.on('close', () => {
+      log.info('Finished converting');
+    });
+  });
+};

--- a/src/importMysqlDump.js
+++ b/src/importMysqlDump.js
@@ -21,10 +21,14 @@ module.exports = function importDump(file, logFactory) {
     dropDatabase(dbFile, sqliteLog, () => {
       const executor = new DumpExecutor({ debug: true, filename: dbFile }, sqliteLog);
 
+      log.info('Start importing data into sqlite');
       fs.createReadStream(targetFile, { encoding: 'utf8' })
         .on('error', log.error)
         .on('data', executor.addData)
-        .on('finish', () => log.info('Finished import'));
+        .on('end', () => {
+          executor.finish();
+          log.info('Finished import');
+        });
     });
   });
 };

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,5 +1,5 @@
 'use strict';
-exports.migrate = function migrate(loggerFactory) {
+module.exports = function migrate(loggerFactory) {
   const log = loggerFactory('general');
   log.info('🌈');
 };

--- a/src/sqlite/DumpExecutor.js
+++ b/src/sqlite/DumpExecutor.js
@@ -1,0 +1,70 @@
+'use strict';
+const sqlite3 = require('sqlite3');
+
+module.exports = class DumpExecutor {
+
+  constructor(opts, log) {
+    this._log = log;
+    this._queuedLines = [];
+    this._queuedQueries = [];
+    this._database = null;
+
+    this.opts = opts;
+
+    this.addData = this.addData.bind(this);
+  }
+
+  addData(data) {
+    // start opening the database
+    if (!this._database) this._getOpenDatabase();
+
+    const lines = data.toString()
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line !== '');
+
+    lines.forEach(line => {
+      this._addLine(line);
+    });
+
+    this._tryExecute();
+  }
+
+  _addLine(line) {
+    this._queuedLines.push(line);
+    if (line.endsWith(';')) {
+      this._queuedQueries.push(this._queuedLines.join(' '));
+      this._queuedLines = [];
+    }
+  }
+
+  _getOpenDatabase(callback) {
+    if (!this._database) {
+      const sqlite = this.opts.debug ? sqlite3.verbose() : sqlite3;
+      if (!this.opts.filename) throw Error('Missing options "filename" for DumpExecutor');
+
+      this._database = new sqlite.Database(this.opts.filename, () => {
+        this._log.debug('Database opened');
+        if (callback) callback(null, this._database);
+      });
+    }
+
+    if (callback) {
+      if (this._database.open) callback(null, this._database);
+      else this._database.once('open', () => callback(null, this._database));
+    }
+  }
+
+  _tryExecute() {
+    if (this._queuedQueries.length === 0) return;
+
+    this._getOpenDatabase((err, database) => {
+      this._queuedQueries.forEach(query => {
+        this._log.debug('Execute query', query);
+        database.exec(query);
+      });
+
+      this._queuedQueries = [];
+    });
+  }
+};

--- a/src/sqlite/dropDatabase.js
+++ b/src/sqlite/dropDatabase.js
@@ -1,0 +1,9 @@
+'use strict';
+const fs = require('fs');
+
+module.exports = function dropDatabase(databaseFile, log, callback) {
+  fs.unlink(databaseFile, () => {
+    log.info('Dropped current database.');
+    if (callback) callback();
+  });
+};

--- a/src/utils/formatCliMessages.js
+++ b/src/utils/formatCliMessages.js
@@ -1,0 +1,8 @@
+'use strict';
+module.exports = callback => data => {
+  data.toString().split('\n').forEach(msg => {
+    if (msg) {
+      callback(msg.trim());
+    }
+  });
+};

--- a/src/utils/formatCliMessages.js
+++ b/src/utils/formatCliMessages.js
@@ -1,8 +1,0 @@
-'use strict';
-module.exports = callback => data => {
-  data.toString().split('\n').forEach(msg => {
-    if (msg) {
-      callback(msg.trim());
-    }
-  });
-};


### PR DESCRIPTION
This adds the possibility to import the phabricator mysql dump into sqlite, so it can be easily consumed in the migrations scripts. 
- [x] Convert mysql dump to sqlite dump
- [x] Import dump
- [x] Possibility to purge db
- [x] Provide dump
- [x] Update README with info on how to bootstrap the data
